### PR TITLE
feat: post message to learning mfe on problem submit

### DIFF
--- a/gymtheme/templates/gym-theme/lms/templates/problem.html
+++ b/gymtheme/templates/gym-theme/lms/templates/problem.html
@@ -52,8 +52,14 @@ from openedx.core.djangolib.markup import HTML, Text
       % endif
     </div>
     <div class="submit-attempt-container">
-      <button type="button" class="submit btn btn-brand" data-submitting="${ submit_button_submitting }" data-value="${ submit_button }" data-should-enable-submit-button="${ should_enable_submit_button }" aria-describedby="submission_feedback_${short_id}" ${'' if should_enable_submit_button else 'disabled'}>
-          <span class="submit-label">${ submit_button }</span>
+      <button type="button" class="submit btn-brand"
+        data-submitting="${ submit_button_submitting }"
+        data-value="${ submit_button }"
+        data-should-enable-submit-button="${ should_enable_submit_button }"
+        aria-describedby="submission_feedback_${short_id}"
+        ${'' if should_enable_submit_button else 'disabled'}
+        onclick="notifySubmission()">
+        <span class="submit-label">${ submit_button }</span>
       </button>
 
       % if submit_disabled_cta:
@@ -166,4 +172,19 @@ from openedx.core.djangolib.markup import HTML, Text
     function emit_event(message) {
         parent.postMessage(message, '*');
     }
+</script>
+
+<script>
+  function emit_event(message) {
+      parent.postMessage(message, '*');
+  }
+
+  function notifySubmission() {
+      // Send message to parent window about submission
+      parent.postMessage({
+          type: 'problem_check',
+          action: 'submit',
+          problemId: '${ problem["name"] }'
+      }, '*');
+  }
 </script>


### PR DESCRIPTION
To be able to show the Certificate celebration component to the user on the Learning MFE we need to notify MFE for the problem check event. This change implements a simple notification to MFE when user clicks on Submit button, it tells to the MFE what event triggered, what was the problem id and what was the action and on the Learning MFE we can use this as a condition to execute a logic to see if user got a passing grade and if yes showing the celebration component